### PR TITLE
[WIP:] Add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report bugs or strange behaviours
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+## Expected Behavior
+<!--- delete this line and Tell us what should happen -->
+
+## Current Behavior
+<!--- delete this line and Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!---delete this line and (Not obligatory) suggest a fix/reason for the bug, -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context (Environment)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea or feature for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Please describe your idea or feature request.**
+<!-- delete this line and add a clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- delete this line and add a clear and concise description of what you want to happen.-->
+
+**Describe alternatives you've considered**
+<!-- delete this line and add a clear and concise description of any alternative solutions or features you've considered.-->
+
+**Additional context**
+<!-- <!-- delete this line and add add any other context or screenshots about the feature request here.-->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,9 @@
+# Related Issue
+- 
+
+## Proposed changes
+- 
+- 
+
+## Additional info
+- 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,9 +1,0 @@
-# Related Issue
-- 
-
-## Proposed changes
-- 
-- 
-
-## Additional info
-- 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+# Related Issue
+- Issue goes here (#issueNumber)
+
+## Proposed changes
+- change 1
+- change 2
+
+## Additional info
+- Some important or technical information


### PR DESCRIPTION
@paulojribp revisar estes templates que serão base para criar issues
https://github.com/Java-DevZone/cotas-backend/commit/ee2183fb422d73f14b6816ae0917caaa33f4c76c
https://github.com/Java-DevZone/cotas-backend/commit/2400aa5522eded56e3445d5cd7e381ab1eb30188

Este é o template das PRs
https://github.com/Java-DevZone/cotas-backend/pull/13/commits/766ba2a66818ed1b98489697ab27b49b88506376

A abertura de issues ficará assim, cada botão leva para uma abertura de issue com template
padrão.

![Screen Shot 2020-03-01 at 5 09 55 PM](https://user-images.githubusercontent.com/5461553/75632943-955dab80-5bdf-11ea-944e-45b90c2eb425.png)
